### PR TITLE
chore: update .swift-format to 600.0.0

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -55,6 +55,7 @@
     "ReturnVoidInsteadOfEmptyTuple" : true,
     "TypeNamesShouldBeCapitalized" : true,
     "UseEarlyExits" : true,
+    "UseExplicitNilCheckInConditions" : true,
     "UseLetInEveryBoundCaseVariable" : true,
     "UseShorthandTypeNames" : true,
     "UseSingleLinePropertyGetter" : true,


### PR DESCRIPTION
swift-format 600.0.0 has introduced a new rule, `UseExplicitNilCheckInConditions`.